### PR TITLE
fix(frontend): stop dashboard 401s and SPA 404s; add wasm/js MIME hea…

### DIFF
--- a/frontend/src/hooks/useDriverSeasonStats.ts
+++ b/frontend/src/hooks/useDriverSeasonStats.ts
@@ -31,7 +31,11 @@ export const useDriverSeasonStats = (driverId?: string) => {
         setLoading(true);
         setError(null);
         
-        const token = await getAccessTokenSilently();
+        const token = await getAccessTokenSilently({
+          authorizationParams: {
+            audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+          },
+        });
         const data = await apiFetch<SeasonStatsData[]>(`/api/drivers/${driverId}/season-stats`, {
           headers: { Authorization: `Bearer ${token}` },
         });

--- a/frontend/src/hooks/useDriverStandings.ts
+++ b/frontend/src/hooks/useDriverStandings.ts
@@ -31,7 +31,11 @@ export const useDriverStandings = (season: number) => {
         setLoading(true);
         setError(null);
 
-        const token = await getAccessTokenSilently();
+        const token = await getAccessTokenSilently({
+          authorizationParams: {
+            audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+          },
+        });
         const response = await fetch(buildApiUrl(`/api/drivers/standings/${season}`), {
           headers: { Authorization: `Bearer ${token}` },
         });

--- a/frontend/src/hooks/useProfile.ts
+++ b/frontend/src/hooks/useProfile.ts
@@ -22,7 +22,11 @@ export const useProfile = () => {
 
   const fetchProfile = useCallback(async () => {
     try {
-      const token = await getAccessTokenSilently();
+      const token = await getAccessTokenSilently({
+        authorizationParams: {
+          audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+        },
+      });
       const response = await fetch(buildApiUrl('/api/profile'), {
         headers: { Authorization: `Bearer ${token}` },
       });
@@ -35,7 +39,11 @@ export const useProfile = () => {
   }, [getAccessTokenSilently]);
 
   const updateProfile = useCallback(async (payload: Partial<ProfileResponse>) => {
-    const token = await getAccessTokenSilently();
+    const token = await getAccessTokenSilently({
+      authorizationParams: {
+        audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+      },
+    });
     const res = await fetch(buildApiUrl('/api/profile'), {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },

--- a/frontend/src/hooks/useUserProfile.ts
+++ b/frontend/src/hooks/useUserProfile.ts
@@ -44,7 +44,11 @@ export function useUserProfile() {
     let token: string | undefined;
     try {
       // Use provider defaults (audience/scope) to avoid scope mismatch
-      token = await getAccessTokenSilently();
+      token = await getAccessTokenSilently({
+        authorizationParams: {
+          audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+        },
+      });
     } catch (err: any) {
       const message = String(err?.message || err);
       console.error('❌ [useUserProfile] getAccessTokenSilently error:', message);

--- a/frontend/src/hooks/useUserRegistration.ts
+++ b/frontend/src/hooks/useUserRegistration.ts
@@ -9,7 +9,11 @@ export const useUserRegistration = () => {
     try {
       // REMOVED: The incorrect authorizationParams that limited the scope.
       // Now, it will use the default scope from your Auth0Provider, which includes the email.
-      const token = await getAccessTokenSilently();
+      const token = await getAccessTokenSilently({
+        authorizationParams: {
+          audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+        },
+      });
 
       const response = await fetch(buildApiUrl('/api/users/ensure-exists'), {
         method: 'POST',

--- a/frontend/src/pages/CompareDriversPage/CompareDriversPage.tsx
+++ b/frontend/src/pages/CompareDriversPage/CompareDriversPage.tsx
@@ -325,7 +325,11 @@ const CompareDriversPage = () => {
   // Function to fetch driver career info
   const fetchDriverCareerInfo = async (driverId: string) => {
     try {
-      const token = await getAccessTokenSilently();
+      const token = await getAccessTokenSilently({
+        authorizationParams: {
+          audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+        },
+      });
       const response = await fetch(buildApiUrl(`/api/drivers/${driverId}/career-stats`), {
         headers: { 
           'Authorization': `Bearer ${token}`,

--- a/frontend/src/pages/Dashboard/widgets/FavoriteTeamSnapshotWidget.tsx
+++ b/frontend/src/pages/Dashboard/widgets/FavoriteTeamSnapshotWidget.tsx
@@ -25,7 +25,11 @@ function FavoriteTeamSnapshotWidget() {
       try {
         if (!favoriteConstructor || seasons.length === 0) return;
         const season = new Date().getFullYear();
-        const token = await getAccessTokenSilently();
+        const token = await getAccessTokenSilently({
+          authorizationParams: {
+            audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+          },
+        });
         const constructorId = (favoriteConstructor as any).id;
         
         // Use shared seasons data to find season ID

--- a/frontend/staticwebapp.config.json
+++ b/frontend/staticwebapp.config.json
@@ -6,6 +6,7 @@
   "mimeTypes": {
     ".js": "application/javascript",
     ".mjs": "application/javascript",
+    ".wasm": "application/wasm",
     ".css": "text/css",
     ".html": "text/html"
   },

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,20 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)\\.js",
+      "headers": [{ "key": "Content-Type", "value": "text/javascript" }]
+    },
+    {
+      "source": "/(.*)\\.wasm",
+      "headers": [{ "key": "Content-Type", "value": "application/wasm" }]
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/((?!api/).*)",
+      "destination": "/index.html"
+    }
+  ]
+}
+
+


### PR DESCRIPTION
…ders

- Auth0: consistently request access tokens with correct audience
  - useUserRegistration, useUserProfile, useProfile (GET/PATCH), useDriverStandings, useDriverSeasonStats, FavoriteTeamSnapshotWidget, CompareDriversPage
- Routing (Vercel): add SPA rewrites so deep links (e.g. /dashboard) serve index.html
  - frontend/vercel.json with rewrite excluding /api/*
- MIME:
  - Vercel headers for .js (text/javascript) and .wasm (application/wasm)
  - Azure SWA: add .wasm: application/wasm in staticwebapp.config.json

Refs: repeated 401 Unauthorized on /api/profile, 404 NOT_FOUND on SPA routes, module MIME errors