### PR TITLE
Support 2026 season data

### DIFF
--- a/backend/src/ingestion/ergast.service.ts
+++ b/backend/src/ingestion/ergast.service.ts
@@ -116,7 +116,7 @@ export class ErgastService {
 
   // --- CONFIGURATION ---
   private readonly startYear = 2000;
-  private readonly endYear = 2025; // Allow foundational scripts to run for all years 
+  private readonly endYear = 2026; // Allow foundational scripts to run for all years
   private readonly pageLimit = 100; // A higher page limit for faster bulk ingestion
 
   constructor(

--- a/backend/src/ingestion/ingestion.service.ts
+++ b/backend/src/ingestion/ingestion.service.ts
@@ -136,7 +136,7 @@ export class IngestionService {
 
       // === OPENF1 MODERN (2023-2025) ===
       this.logger.log('📡 [Phase 2/2] Running OpenF1 Modern Ingestion...');
-      for (const year of [2023, 2024, 2025]) {
+      for (const year of [2023, 2024, 2025, 2026]) {
         this.logger.log(`Processing year ${year}...`);
         await this.openf1Service.ingestSessionsAndWeather(year);
         await this.openf1Service.ingestGranularData(year);

--- a/frontend/src/pages/DriverDetailPage/DriverDetailPage.tsx
+++ b/frontend/src/pages/DriverDetailPage/DriverDetailPage.tsx
@@ -24,12 +24,14 @@ import {
 import TeamLogo from '../../components/TeamLogo/TeamLogo';
 import DriverBioCard from '../../components/DriverBioCard/DriverBioCard';
 import { SEASON_FALLBACK_YEAR } from '../../lib/seasonYear';
+import { useResolvedDefaultSeasonYear } from '../../hooks/useResolvedDefaultSeasonYear';
 
 const DriverDetailPage: React.FC = () => {
   const { driverId } = useParams<{ driverId: string }>();
   const { driverDetails, loading, error } = useDriverDetails(driverId);
   const { seasonStats, loading: seasonStatsLoading } = useDriverSeasonStats(driverId);
   const { progressionData, loading: progressionLoading } = useDriverSeasonProgression(driverId);
+  const { defaultSeasonYear } = useResolvedDefaultSeasonYear();
 
   // --- DEBUG STEP 3: Log the data as it's received by the page component ---
   console.log("%c3. Data Received by Page Component:", "color: orange; font-weight: bold;", driverDetails);
@@ -250,7 +252,7 @@ const DriverDetailPage: React.FC = () => {
         {/* --- AI-GENERATED BIO SECTION --- */}
         <Box mt="xl">
           <Heading size="md" fontFamily="heading" mb="md" color="text-primary">Driver Biography</Heading>
-          <DriverBioCard driverId={Number(driverId)} season={2025} />
+          <DriverBioCard driverId={Number(driverId)} season={defaultSeasonYear} />
         </Box>
       </Container>
     </Box>

--- a/frontend/src/pages/Standings/AnalyticsStandings.test.tsx
+++ b/frontend/src/pages/Standings/AnalyticsStandings.test.tsx
@@ -165,6 +165,12 @@ describe('AnalyticsStandings', () => {
     
     // Mock successful fetch responses
     (global.fetch as any).mockImplementation((url: string) => {
+      if (url.includes('/seasons')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{ id: 26, year: 2025 }]),
+        });
+      }
       if (url.includes('/constructors/')) {
         return Promise.resolve({
           ok: true,

--- a/frontend/src/pages/Standings/AnalyticsStandings.tsx
+++ b/frontend/src/pages/Standings/AnalyticsStandings.tsx
@@ -50,23 +50,60 @@ const AnalyticsStandings: React.FC = () => {
   const [constructorsProgression, setConstructorsProgression] = useState<ConstructorProgression[]>([]);
   const [driversProgression, setDriversProgression] = useState<DriverProgression[]>([]);
   const [loading, setLoading] = useState(true);
-  const [selectedSeason, setSelectedSeason] = useState<number>(2025);
-  const [selectedSeasonId, setSelectedSeasonId] = useState<number>(26); // Default to 2025 season ID
+  const [seasons, setSeasons] = useState<{ id: number; year: number }[]>([]);
+  const [seasonsLoaded, setSeasonsLoaded] = useState(false);
+  const [selectedSeason, setSelectedSeason] = useState<number | null>(null);
+  const [selectedSeasonId, setSelectedSeasonId] = useState<number | null>(null);
   const [seasonChanging, setSeasonChanging] = useState(false);
 
-  // Generate season options from 2025 → 2000 (same as other standings pages)
+  // Map season year -> DB season id, derived from /api/seasons (no hardcoded ids)
+  const yearToSeasonId = useMemo(() => {
+    const map: Record<number, number> = {};
+    seasons.forEach((s) => { map[s.year] = s.id; });
+    return map;
+  }, [seasons]);
+
+  // Season options come straight from the ingested seasons (newest first)
   const seasonOptions: SeasonOption[] = useMemo(() => {
-    const options: SeasonOption[] = [];
-    for (let year = 2025; year >= 2000; year--) {
-      options.push({ value: year, label: year.toString() });
-    }
-    return options;
+    return [...seasons]
+      .sort((a, b) => b.year - a.year)
+      .map((s) => ({ value: s.year, label: s.year.toString() }));
+  }, [seasons]);
+
+  // Load the list of ingested seasons once
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const res = await fetch(buildApiUrl('/api/seasons'));
+        if (!res.ok) throw new Error(`seasons ${res.status}`);
+        const data = await res.json();
+        if (alive && Array.isArray(data)) {
+          setSeasons(data.filter((s) => typeof s?.id === 'number' && typeof s?.year === 'number'));
+        }
+      } catch (err) {
+        console.error('Failed to load seasons', err);
+      } finally {
+        if (alive) setSeasonsLoaded(true);
+      }
+    })();
+    return () => { alive = false; };
   }, []);
 
-  // Set default season ID for 2025
+  // Once the default year is resolved and seasons are loaded, select it
+  // (falling back to the newest ingested season if the default isn't present)
   useEffect(() => {
-    setSelectedSeasonId(26); // 2025 season ID
-  }, []);
+    if (resolvingDefaultSeason || !seasonsLoaded || selectedSeasonId !== null) return;
+    if (seasons.length === 0) {
+      // Nothing to show; drop out of the skeleton state.
+      setLoading(false);
+      return;
+    }
+    const sorted = [...seasons].sort((a, b) => b.year - a.year);
+    const target = sorted.find((s) => s.year === defaultSeasonYear) ?? sorted[0];
+    setSelectedSeason(target.year);
+    setSelectedSeasonId(target.id);
+  }, [resolvingDefaultSeason, seasonsLoaded, seasons, defaultSeasonYear, selectedSeasonId]);
 
   // Theme-aware colors
   const chartBgColor = useColorModeValue('white', 'gray.900');
@@ -113,38 +150,9 @@ const AnalyticsStandings: React.FC = () => {
   const handleSeasonChange = async (newSeason: number) => {
     setSeasonChanging(true);
     setSelectedSeason(newSeason);
-    
-    // Map year to season ID (this is a simplified mapping - in production you might want to fetch this from API)
-    const seasonIdMapping: Record<number, number> = {
-      2025: 26,
-      2024: 25,
-      2023: 24,
-      2022: 23,
-      2021: 22,
-      2020: 21,
-      2019: 20,
-      2018: 19,
-      2017: 18,
-      2016: 17,
-      2015: 16,
-      2014: 15,
-      2013: 14,
-      2012: 13,
-      2011: 12,
-      2010: 11,
-      2009: 10,
-      2008: 9,
-      2007: 8,
-      2006: 7,
-      2005: 6,
-      2004: 5,
-      2003: 4,
-      2002: 3,
-      2001: 2,
-      2000: 1,
-    };
-    
-    const seasonId = seasonIdMapping[newSeason];
+
+    // Map year -> season id from the ingested seasons (see yearToSeasonId)
+    const seasonId = yearToSeasonId[newSeason];
     if (seasonId) {
       setSelectedSeasonId(seasonId);
     }


### PR DESCRIPTION
Backend: widen ingestion year bounds to include 2026
- ergast.service: endYear 2025 -> 2026 so seasons/races/results/standings loops cover 2026
- ingestion.service: add 2026 to the OpenF1 full-pipeline year list

Frontend: remove hardcoded 2025 season assumptions so 2026 surfaces once ingested
- AnalyticsStandings: derive year->season-id map and season options from /api/seasons instead of a hardcoded season id (26) and static mapping; initialise the selected season from the resolved default year
- DriverDetailPage: use the resolved default season year for the bio card instead of a literal 2025